### PR TITLE
add license to distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include README.rst
+include README.rst LICENSE


### PR DESCRIPTION
Thanks for this tool!

This PR ensures future releases will include the `LICENSE` file: it's possible newer `setuptools` would do this automatically, but _explicit is better than implicit_, I suppose.